### PR TITLE
Organize paper outputs into timestamped subdirectories

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains a simple automation pipeline that uses OpenAI's GPT-5 t
 
 - Prompt the user for a research topic.
 - Generate a high-value, innovative and practical research idea using GPT-5.
-- Draft a full research paper with sections (Abstract, Introduction, Methodology, Experiments, Results, Conclusion) and associated code, saved to an output directory.
+- Draft a full research paper with sections (Abstract, Introduction, Methodology, Experiments, Results, Conclusion) and associated code, saved to a unique subdirectory inside an output directory.
 - Peer review the generated paper using GPT-5 acting as a top journal reviewer and provide constructive feedback.
 - Automatically decide whether the paper is ready for submission. If not, revise the paper based on the review feedback and produce a unified diff showing the changes.
 - Apply the diff to update the paper and any associated code.
@@ -27,4 +27,4 @@ export OPENAI_API_KEY=YOUR_API_KEY
 python sciresearch_workflow.py --topic "quantum computing algorithms" --output-dir ./output
 ```
 
-The script will generate a research idea, write a paper into the specified output directory (`output/paper.md`), review and revise it if necessary.
+The script will generate a research idea, write a paper into a timestamped subdirectory within the specified output directory (e.g., `output/20230826_123456/paper.tex`), review and revise it if necessary.


### PR DESCRIPTION
## Summary
- Save generated papers and code into timestamped subdirectories so multiple runs can coexist.
- Change `save_paper_and_code` to return the subdirectory path and update workflow logic accordingly.
- Document new output structure in the README.

## Testing
- `python -m py_compile sciresearch_workflow.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68ad5b40b8b4832a9b07c00fc4cc629a